### PR TITLE
[Surreal] Transaction route updates and further Kromer improvements discussion

### DIFF
--- a/src/errors/transaction.rs
+++ b/src/errors/transaction.rs
@@ -10,6 +10,9 @@ pub enum TransactionError {
 
     #[error("Failed to create transaction")]
     FailedCreate,
+
+    #[error("Sender has insufficient funds")]
+    InsufficientFunds
 }
 
 impl error::ResponseError for TransactionError {
@@ -18,6 +21,7 @@ impl error::ResponseError for TransactionError {
             TransactionError::NotFound => StatusCode::NOT_FOUND,
             TransactionError::InvalidAmount => StatusCode::BAD_REQUEST,
             TransactionError::FailedCreate => StatusCode::INTERNAL_SERVER_ERROR,
+            TransactionError::InsufficientFunds => StatusCode::BAD_REQUEST,
         }
     }
 }

--- a/src/routes/v1/transaction.rs
+++ b/src/routes/v1/transaction.rs
@@ -64,6 +64,11 @@ async fn transaction_create(
         .await?
         .ok_or_else(|| KromerError::Wallet(WalletError::NotFound))?;
 
+    // Make sure to check the request to see if the funds are available.
+    if sender.balance < details.amount {
+        return Err(KromerError::Transaction(TransactionError::InsufficientFunds))
+    }
+
     let creation_data = TransactionCreateData {
         from: sender.id.unwrap(), // `unwrap` should be fine here, we already made sure it exists.
         to: recipient.id.unwrap(),

--- a/src/routes/v1/transaction.rs
+++ b/src/routes/v1/transaction.rs
@@ -39,7 +39,7 @@ async fn transaction_get(
     let id = id.into_inner();
     let db = &state.db;
 
-    let slim = Transaction::get(db, id).await?;
+    let slim = Transaction::get_partial(db, id).await?;
 
     Ok(HttpResponse::Ok().json(slim))
 }


### PR DESCRIPTION
# This draft PR addresses the following:
- When creating a transaction, check the sender's balance for the case of insufficient funds, so that the sender cannot possibly go into negative balance
- When getting a transaction by ID in the API, use the "get_partial" function that allows for constructing an ID by only the string value of the ID itself. This prevents having to use "transaction:id" format in the address of the API request. 

I'll make a best effort to update this PR with any further considerations below after feedback from the team. I can move these individual considerations into "Issues" as requested as well. Thanks!

# Further considerations for Kromer API design
- Currently, the data returned from Surreal directly is formatted in ways the Surreal database structures the data, such as "from" and "to" addresses in returned transactions containing data specific to Surreal (shown below). I'm considering either using Surreal's custom functions to format the queries properly directly from the database side, or ways to alter the queries coming from the API to structure/filter extraneous DB information in a way that is friendly to consume from the API
```json 
{
  "amount": 5,
  "from": {
    "tb": "wallet",
    "id": {
      "String": "54kcbnigh3ljg9po3mnz"
    }
  },
  "timestamp": "2024-12-28T06:49:43.564974235Z",
  "to": {
    "tb": "wallet",
    "id": {
      "String": "blw276siwgde6hb6x8lu"
    }
  }
}
```
- Migration/database setup support. This is something I'm still exploring to see how [this tool](https://github.com/Odonno/surrealdb-migrations) works for the flow of database setup and migrations. So far, it seems as if the migration files can be written by hand as needed, and will be applied in a consistent manner for future (re-)deployments of the Kromer API. The tool itself may not be as useful for generating new migrations, as much as a migration runner/util for applying consistent database updates. This consideration will not matter as much until Kromer is deployed/stable, as redeploys can just start from a fresh DB state each time until then.
- Handling multiple wallets/addresses per Minecraft player. Currently, wallets are created from the API internal route and create a corresponding owning player at the same time, erroring if the player already exists (and thus owns one wallet already). Direction is requested to scope the potential for shared wallets/addresses, limits on wallet creation, and cases where players owning multiple wallets may not be desired 
- Logic that is inside the API route definitions might be useful to the future WebSocket implementation. Consider that we move these bits of logic into "controllers", which can be called with the appropriate request/WS payload information anonymously for the same logic to be used in both places.
- A testing suite for the REST API and future WS API would be desirable. Integration tests are possible [directly through Actix](https://actix.rs/docs/testing/), and WS testing is available through a [setup like this](https://gist.github.com/dipsywong98/fa2a1687f23d03cb006bae86df92548f)
 